### PR TITLE
Add more default secret patterns

### DIFF
--- a/lib/load.ts
+++ b/lib/load.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020 Atomist, Inc.
+ * Copyright © 2021 Atomist, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,19 +39,19 @@ export interface SecretDefinition {
 }
 
 /**
- * Based on regular expressions in https://www.ndss-symposium.org/wp-content/uploads/2019/02/ndss2019_04B-3_Meli_paper.pdf
+ * Load the default patterns.
  */
 export async function loadPattern(): Promise<SecretDefinition[]> {
 	const secretsYmlPath = path.join(__dirname, "..", "secrets.yaml");
-	const yamlString = await fs.readFile(secretsYmlPath);
-	const native: any = await yaml.safeLoad(yamlString.toString());
+	const yamlString = await fs.readFile(secretsYmlPath, "utf8");
+	const native: any = yaml.safeLoad(yamlString);
 
 	const secretDefinitions: SecretDefinition[] = native.secrets
 		.map((s: any) => s.secret)
 		.map((s: any) => ({
 			pattern: s.pattern,
 			description: s.description,
-			ignore: s.ignore,
+			ignore: s.ignore || [],
 		}));
 
 	return secretDefinitions;

--- a/secrets.yaml
+++ b/secrets.yaml
@@ -1,4 +1,4 @@
-# Copyright © 2020 Atomist, Inc.
+# Copyright © 2021 Atomist, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,55 +12,93 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# List of secrets, with regex and description
 secrets:
-  # List of secrets, with regex and description
-  # These come from Table III at https://www.ndss-symposium.org/wp-content/uploads/2019/02/ndss2019_04B-3_Meli_paper.pdf
+  # Table III of https://www.ndss-symposium.org/wp-content/uploads/2019/02/ndss2019_04B-3_Meli_paper.pdf
   - secret:
-      pattern: "[1-9][0-9]+-[0-9a-zA-Z]{40}"
-      description: "Twitter access token"
+      pattern: '\b[1-9][0-9]+-[0-9a-zA-Z]{40}\b'
+      description: Twitter access token
       ignore:
         - package-lock.json
         - yarn.lock
         - pnpm-lock.yaml
   - secret:
-      pattern: "EAACEdEose0cBA[0-9A-Za-z]+"
-      description: "Facebook access token"
+      pattern: '\bEAACEdEose0cBA[0-9A-Za-z]+'
+      description: Facebook access token
   - secret:
-      pattern: 'AIza[0-9A-Za-z\-_]{35}'
-      description: "Google API key"
+      pattern: '\bAIza[0-9A-Za-z\-_]{35}\b'
+      description: Google API key
   - secret:
-      pattern: '[0-9]+-[0-9A-Za-z_]{32}\.apps\.googleusercontent\.com'
-      description: "Google Oauth ID"
+      pattern: '\b[0-9]+-[0-9A-Za-z_]{32}\.apps\.googleusercontent\.com\b'
+      description: Google OAuth ID
   - secret:
-      pattern: "sk_live_[0-9a-z]{32}"
-      description: "Picatic API Key"
+      pattern: '\bsk_live_[0-9a-z]{32}\b'
+      description: Picatic API Key
   - secret:
-      pattern: "sk_live_[0-9a-zA-Z]{24}"
-      description: "Stripe regular API key"
+      pattern: '\bsk_live_[0-9a-zA-Z]{24}\b'
+      description: Stripe standard API key
   - secret:
-      pattern: 'sq0csp-[0-9A-Za-z\-_]{43}'
-      description: "Stripe restricted API key"
+      pattern: '\brk_live_[0-9a-zA-Z]{24}\b'
+      description: Stripe restricted API key
   - secret:
-      pattern: 'sq0atp-[0-9A-Za-z\-_]{22}'
-      description: "Square access token"
+      pattern: '\bsq0atp-[0-9A-Za-z\-_]{22}\b'
+      description: Square access token
   - secret:
-      pattern: 'sq0csp-[0-9A-Za-z\-_]{43}'
-      description: "Square Oauth Secret"
+      pattern: '\bsq0csp-[0-9A-Za-z\-_]{43}\b'
+      description: Square OAuth Secret
   - secret:
-      pattern: 'access_token\$production\$[0-9a-z]{16}\$[0-9a-f]{32}'
-      description: "PayPal Braintree access token"
+      pattern: '\baccess_token\$production\$[0-9a-z]{16}\$[0-9a-f]{32}\b'
+      description: PayPal Braintree access token
   - secret:
-      pattern: 'amzn\.mws\.[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'
-      description: "Amazon MWS auth token"
+      pattern: '\bamzn\.mws\.[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b'
+      description: Amazon MWS auth token
   - secret:
-      pattern: "SK[0-9a-fA-F]{32}"
-      description: "Twilio API key"
+      pattern: '\bSK[0-9a-fA-F]{32}\b'
+      description: Twilio API key
   - secret:
-      pattern: "key-[0-9a-zA-Z]{32}"
-      description: "MailGun API key"
+      pattern: '\bkey-[0-9a-zA-Z]{32}\b'
+      description: MailGun API key
   - secret:
-      pattern: "[0-9a-f]{32}-us[0-9]{1,2}"
-      description: "MailChimp API key"
+      pattern: '\b[0-9a-f]{32}-us[0-9]{1,2}\b'
+      description: MailChimp API key
   - secret:
-      pattern: "AKIA[0-9A-Z]{16}"
-      description: "AWS access key ID"
+      pattern: '\bAKIA[0-9A-Z]{16}\b'
+      description: AWS access key ID
+  # Atomist contributed
+  - secret:
+      pattern: '(?<!v1\.)\b[A-Fa-f0-9]{40}\b'
+      description: GitHub personal access or OAuth2 token
+      # avoid files commonly containing git commit SHAs
+      ignore:
+        - CHANGELOG.md
+        - package-lock.json
+        - yarn.lock
+        - pnpm-lock.yaml
+  - secret:
+      pattern: '\bv1\.[a-f0-9]{40}\b'
+      description: GitHub App access token
+  - secret:
+      pattern: '\b(?:ht|f|sm)tps?://[^:/?#\[\]@"<>{}|\\^`\s]*:[^:/?#\[\]@"<>{}|\\^`\s]+@'
+      description: URL with password
+  # https://github.com/odomojuli/RegExAPI
+  - secret:
+      pattern: '\b[0-9a-fA-F]{7}\.[0-9a-fA-F]{32}\b'
+      description: Instagram OAuth2 token
+  - secret:
+      pattern: '\bR_[0-9a-f]{32}\b'
+      description: Foursquare secret key
+  - secret:
+      pattern: '\bxox[baprs]-[0-9]{12}-[0-9]{12}-[0-9a-zA-Z]{24}\b'
+      description: Slack API key
+  - secret:
+      pattern: '\b[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\b'
+      description: GCP OAuth2 token
+  - secret:
+      pattern: '\b[A-Za-z0-9_]{21}--[A-Za-z0-9_]{8}\b'
+      description: GCP API key
+  - secret:
+      pattern: '\b[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\b'
+      description: Heroku API key
+  - secret:
+      pattern: '\b[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\b'
+      description: Heroku OAuth2 token


### PR DESCRIPTION
Add secret patterns for GitHub tokens, URLs with passwords, Instagram,
Foursquare, Slack, GCP, and Heroku. Add word boundaries to secret
patterns, as appropriate. Add tests.